### PR TITLE
Change to config read from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Change to read all command line parameters in config toml file.
+  - Removes the option to start from a specific line (`-f`), since skip
+    lines also allow sending from a specific line.
+  - Modify the skip count/send count/last sent line options(`-s`/`-c`/`-r`),
+    which only worked with logs, to work with all conditions.
+  - Modify it so that folder polling is applied first.
+  - Remove the option for output type.(`-o`) The associated functionality
+    is now deprecated.
+
 ## [0.18.0] - 2024-01-25
 
 ### Added
@@ -290,6 +303,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   Docker, you should bind the `/report` to see the report file from the host.
 - Dockerfile changed to use g++-8
 
+[Unreleased]: https://github.com/aicers/reproduce/compare/0.18.0...main
 [0.18.0]: https://github.com/aicers/reproduce/compare/0.17.5...0.18.0
 [0.17.5]: https://github.com/aicers/reproduce/compare/0.17.4...0.17.5
 [0.17.4]: https://github.com/aicers/reproduce/compare/0.17.3...0.17.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-trait"
+version = "0.1.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531b97fb4cd3dfdce92c35dedbfdc1f0b9d8091c8ca943d6dae340ef5012d514"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +241,20 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "config"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "serde",
+ "toml 0.5.11",
+]
 
 [[package]]
 name = "core-foundation"
@@ -923,6 +948,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "pcap"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,6 +1193,7 @@ dependencies = [
  "bytesize",
  "chrono",
  "clap",
+ "config",
  "csv",
  "ctrlc",
  "giganto-client",
@@ -1181,7 +1213,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "toml",
+ "toml 0.8.8",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -1709,6 +1741,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ byteorder = "1.5"
 bytesize = "1"
 chrono = ">=0.4.35"
 clap = { version = "4.4", features = ["wrap_help"] }
+config = { version = "0.13", features = ["toml"], default-features = false }
 csv = "1.3"
 ctrlc = { version = "3", features = ["termination"] }
 giganto-client = { git = "https://github.com/aicers/giganto-client.git", tag = "0.15.2" }

--- a/README.md
+++ b/README.md
@@ -42,39 +42,118 @@ the environment variable `NETFLOW_TEMPLATES_PATH`.
 
 ## Examples
 
-* Convert a zeek log file and send it to Giganto server from specific line:
+* Information about all config fields is as follows
 
-  ```sh
-  reproduce -i LOG_20220921 -o giganto -G 127.0.0.1:38370 -N server_name \
-      -C config.toml -k protocol -f 10
+  ```toml
+  [common]
+  cert = "tests/cert.pem"                  # Path to private key file.
+  key = "tests/key.pem"                    # Path to certificate file.
+  root = "tests/root.pem"                  # Path to CA certificate file.
+  giganto_ingest_addr = "127.0.0.1:38370"  # Address of the giganto ingest.
+  giganto_name = "aicers"                  # Giganto server name.
+  kind ="http"                             # Data kind. Default is empty string.
+  input = "/path/to/file_or_directory"     # Input type. (file/directory/"elastic")
+  report = false             # Flag for transfer stats report. Default is false.
+
+  [file]
+  export_from_giganto = true # Giganto export file type flag. Default is false.
+  polling_mode = false              # File polling mode flag. Default is false.
+  transfer_count = 0                       # The number of line/packet to sent.
+  transfer_skip_count = 0                  # The number of line/packet to skip.
+  last_transfer_line_suffix = "bck"        # A suffix string for the new file
+                                           # where info about the last transfer
+                                           # line will be stored.
+
+  [directory]
+  file_prefix = "http"                     # Prefix of the file name.
+  polling_mode = false        # Directory polling mode flag. Default is false.
+
+  [elastic]
+  url = "http://127.0.0.1:9200/"               # Elasticsearch server url.
+  event_codes = ["1","7","11","17","25","26",] # Target event kind
+  indices = [".ds-winlogbeat-8.8.2-2023.11.29-000001"]  # elasticsearch index.
+  start_time = "2023-08-06T15:00:00.000Z"      # Target start/end time.
+  end_time = "2023-09-07T02:00:00.000Z"
+  size = 100000                                # Fetch size.
+  dump_dir = "tests/dump"                      # Csv dump path.
+  elastic_auth = "admin:admin"                 # Elastic auth info. (id/pw)
+  ```
+
+* Convert a zeek log file and send it to Giganto server:
+
+  ```toml
+  [common]
+  cert = "tests/cert.pem"
+  key = "tests/key.pem"
+  root = "tests/root.pem"
+  giganto_ingest_addr = "127.0.0.1:38370"
+  giganto_name = "aicers"
+  kind ="dns"                                # kind in `Network Events` at the bottom.
+  input = "/path/to/zeek_file"
   ```
 
 * Send operation log to Giganto server:
 
-  ```sh
-  reproduce -i AGENT_NAME.log -o giganto -G 127.0.0.1:38370 -N server_name \
-    -C config.toml -k oplog
+  ```toml
+  [common]
+  cert = "tests/cert.pem"
+  key = "tests/key.pem"
+  root = "tests/root.pem"
+  giganto_ingest_addr = "127.0.0.1:38370"
+  giganto_name = "aicers"
+  kind ="oplog"                              # Use a fixed kind value.
+  input = "/path/to/oplog_file"
   ```
 
 * Send giganto export file to Giganto server:
 
-  ```sh
-  reproduce -i LOG_20230209 -o giganto -G 127.0.0.1:38370 -N server_name \
-    -C config.toml -k protocol -m
+  ```toml
+  [common]
+  cert = "tests/cert.pem"
+  key = "tests/key.pem"
+  root = "tests/root.pem"
+  giganto_ingest_addr = "127.0.0.1:38370"
+  giganto_name = "aicers"
+  kind ="http"                               # kind in `Network Events` at the bottom
+  input = "/path/to/giganto_export_file"
+
+  [file]
+  export_from_giganto = true
   ```
 
 * Send sysmon csv file to Giganto server:
 
-  ```sh
-  reproduce -i EVENT_LOG.csv -o giganto -G 127.0.0.1:38370 -N server_name \
-    -C config.toml -k event_name
+  ```toml
+  [common]
+  cert = "tests/cert.pem"
+  key = "tests/key.pem"
+  root = "tests/root.pem"
+  giganto_ingest_addr = "127.0.0.1:38370"
+  giganto_name = "aicers"
+  kind ="image_load"                         # kind in `Sysmon Events` at the bottom.
+  input = "/path/to/sysmon_file"
   ```
 
 * Send sysmon with elastic search to Giganto server:
 
-  ```sh
-  reproduce -i elastic -o giganto -G 127.0.0.1:38370 -N server_name \
-    -C config.toml -E id:password
+  ```toml
+  [common]
+  cert = "tests/cert.pem"
+  key = "tests/key.pem"
+  root = "tests/root.pem"
+  giganto_ingest_addr = "127.0.0.1:38370"
+  giganto_name = "aicers"
+  input = "elastic"                          # Use a fixed input value.
+
+  [elastic]
+  url = "http://127.0.0.1:9200/"
+  event_codes = ["1","7","11","17","25","26",]
+  indices = [".ds-winlogbeat-8.8.2-2023.11.29-000001"]
+  start_time = "2023-08-06T15:00:00.000Z"
+  end_time = "2023-09-07T02:00:00.000Z"
+  size = 100000
+  dump_dir = "tests/dump"
+  elastic_auth = "admin:admin"
   ```
 
 ## Defined kind type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod syslog;
 mod zeek;
 
 use anyhow::Result;
-pub use config::{Config, InputType, OutputType};
+pub use config::{Config, InputType};
 pub use controller::Controller;
 use csv::StringRecord;
 pub use producer::Producer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,27 @@
-use clap::{value_parser, Arg, Command};
+use anyhow::Result;
 use reproduce::{Config, Controller};
-use std::num::NonZeroU64;
+use std::{env, path::PathBuf, process::exit};
 use tokio::task;
 use tracing::{error, info};
 
+const USAGE: &str = "\
+USAGE:
+    REproduce [CONFIG]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARG:
+    <CONFIG>    A TOML config file
+";
+
 #[tokio::main]
-pub async fn main() {
+pub async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
-    let config = parse();
-    let mut controller = Controller::new(config);
+    let config_filename = parse();
+    let config = Config::new(config_filename.as_ref())?;
+    let controller = Controller::new(config);
     info!("reproduce start");
     let _handle = task::spawn(async move {
         if let Err(e) = controller.run().await {
@@ -18,159 +31,34 @@ pub async fn main() {
     })
     .await;
     info!("reproduce end");
+    Ok(())
 }
 
-/// # Panics
-///
-/// Panics if argument parse fail.
-#[allow(clippy::too_many_lines)]
-#[must_use]
-pub fn parse() -> Config {
-    let m = Command::new("reproduce")
-        .version(env!("CARGO_PKG_VERSION"))
-        .arg(
-            Arg::new("count")
-                .short('c')
-                .value_parser(value_parser!(usize))
-                .default_value("0")
-                .help("Send count"),
-        )
-        .arg(
-            Arg::new("eval")
-                .short('e')
-                .help("Evaluation mode. Outputs statistics of transmission."),
-        )
-        .arg(
-            Arg::new("continuous")
-                .short('g')
-                .action(clap::ArgAction::SetTrue)
-                .help("If option exists, continues to read from a growing input file"),
-        )
-        .arg(
-            Arg::new("input")
-                .short('i')
-                .default_value("")
-                .help("Input [LOGFILE/DIR/elastic]."),
-        )
-        .arg(
-            Arg::new("prefix")
-                .short('n')
-                .default_value("")
-                .help("Prefix of file names to send multiple files or a directory"),
-        )
-        .arg(
-            Arg::new("output")
-                .short('o')
-                .default_value("giganto")
-                .help("Output type [TEXTFILE/none/giganto]."),
-        )
-        .arg(Arg::new("offset").short('r').default_value("").help(
-            "Record (prefix of offset file). Using this option will start the conversation \
-                   after the previous conversation. The offset file name is managed by \
-                   <input_file>_<prefix>.",
-        ))
-        .arg(
-            Arg::new("skip")
-                .short('s')
-                .value_parser(value_parser!(usize))
-                .default_value("0")
-                .help("Skip count"),
-        )
-        .arg(
-            Arg::new("polling")
-                .short('v')
-                .help("Polls the input directory"),
-        )
-        .arg(
-            Arg::new("giganto")
-                .short('G')
-                .default_value("127.0.0.1:38370")
-                .help("Giganto server address"),
-        )
-        .arg(
-            Arg::new("name")
-                .short('N')
-                .default_value("localhost")
-                .help("Giganto server hostname."),
-        )
-        .arg(
-            Arg::new("config")
-                .short('C')
-                .default_value("config.toml")
-                .help("config.toml file with cert paths, elastic search configures."),
-        )
-        .arg(
-            Arg::new("kind")
-                .short('k')
-                .default_value("")
-                .help("Giganto log kind."),
-        )
-        .arg(
-            Arg::new("from")
-                .short('f')
-                .value_parser(value_parser!(NonZeroU64))
-                .default_value("1")
-                .help("log from line number(at least 1)"),
-        )
-        .arg(
-            Arg::new("migration")
-                .short('m')
-                .action(clap::ArgAction::SetTrue)
-                .help("if option exists, migration with giganto export file"),
-        )
-        .arg(
-            Arg::new("elastic")
-                .short('E')
-                .default_value("")
-                .help("if input is elastic, [ID:PASSWORD]"),
-        )
-        .get_matches();
-
-    let count_sent = *m.get_one::<usize>("count").expect("has `default_value`");
-    let mode_eval = m.contains_id("eval");
-    let mode_grow = m.get_flag("continuous");
-    let input = m.get_one::<String>("input").expect("has `default_value`");
-    let file_prefix = m.get_one::<String>("prefix").expect("has `default_value`");
-    let output = m.get_one::<String>("output").expect("has `default_value`");
-    let offset_prefix = m.get_one::<String>("offset").expect("has `default_value`");
-    let count_skip = *m.get_one::<usize>("skip").expect("has `default_value`");
-    let config_toml = m.get_one::<String>("config").expect("has `default_value`");
-    let giganto_name = m.get_one::<String>("name").expect("has `default_value`");
-    let giganto_addr = m.get_one::<String>("giganto").expect("has `default_name`");
-    let giganto_kind = m.get_one::<String>("kind").expect("has `default_value`");
-    let elastic_auth = m.get_one::<String>("elastic").expect("has `default_value`");
-    let send_from = m
-        .get_one::<NonZeroU64>("from")
-        .expect("has `default_value`")
-        .get();
-    let migration = m.get_flag("migration");
-    let mode_polling_dir = m.contains_id("polling");
-    if input.is_empty() {
-        error!("input (-i) required.");
-        std::process::exit(1);
+/// Parses the command line arguments and returns the first argument.
+fn parse() -> PathBuf {
+    let args = env::args().collect::<Vec<_>>();
+    if args.len() <= 1 {
+        eprintln!("Error: insufficient arguments");
+        exit(1);
     }
-    if input == "elastic" && elastic_auth.is_empty() {
-        error!("if input is elastic, auth (-E [ID:PASSWORD]) required.");
-        std::process::exit(1);
+    if args.len() > 2 {
+        eprintln!("Error: too many arguments");
+        exit(1);
     }
 
-    Config {
-        mode_eval,
-        mode_grow,
-        mode_polling_dir,
-        count_skip,
-        input: input.to_string(),
-        output: output.to_string(),
-        offset_prefix: offset_prefix.to_string(),
-        file_prefix: file_prefix.to_string(),
-        count_sent,
-        config_toml: config_toml.to_string(),
-        giganto_name: giganto_name.to_string(),
-        giganto_addr: giganto_addr.to_string(),
-        giganto_kind: giganto_kind.to_string(),
-        send_from,
-        migration,
-        elastic_auth: elastic_auth.to_string(),
-        ..Config::default()
+    if args[1] == "--help" || args[1] == "-h" {
+        println!("{}", version());
+        println!();
+        print!("{USAGE}");
+        exit(0);
     }
+    if args[1] == "--version" || args[1] == "-V" {
+        println!("{}", version());
+        exit(0);
+    }
+    PathBuf::from(&args[1])
+}
+
+fn version() -> String {
+    format!("REproduce {}", env!("CARGO_PKG_VERSION"))
 }

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,15 +1,30 @@
-[certification]
+[common]
 cert = "tests/cert.pem"
 key = "tests/key.pem"
-roots = ["tests/root.pem"]
+root = "tests/root.pem"
+giganto_ingest_addr = "127.0.0.1:38370"
+giganto_name = "aicers"
+kind ="http"
+input = "/path/to/file_or_directory"
+report = false
 
-[elasticsearch]
-url = "http://127.0.0.1:9200"
-event_codes = [
-    "1", "2", "3", "5", "7", "11", "13", "14", "15", "17", "22", "23", "25", "26",
-]
+[file]
+export_from_giganto = true
+polling_mode = false
+transfer_count = 0
+transfer_skip_count = 0
+last_transfer_line_suffix = "bck"
+
+[directory]
+file_prefix = "http"
+polling_mode = false
+
+[elastic]
+url = "http://127.0.0.1:9200/"
+event_codes = ["1", "2", "3", "5", "7", "11", "13", "14", "15", "17", "22", "23", "25", "26",]
 indices = [".ds-winlogbeat-8.8.2-2023.11.29-000001"]
 start_time = "2023-08-06T15:00:00.000Z"
 end_time = "2023-09-07T02:00:00.000Z"
 size = 100000
 dump_dir = "tests/dump"
+elastic_auth = "admin:admin"


### PR DESCRIPTION
## 관련 이슈

- Close: #455

## PR 설명

- cron 및 service 등록이 가능하도록 command를 config toml  file로 읽도록 수정.
- 라인 skip 전송(-s)과 중복된 기능을 제공하는 라인 지정 전송 (-f) 옵션을 제거.
- output type 지정(-o) 옵션을 제거. (Kafka를 사용하는 구조에서 필요 했었으나 현재는 필요 없음)
- log type만 사용 가능했던 라인 skip 전송 (-s)/라인 전송 갯수 지정(-c)/마지막 라인 기록 파일 관련 옵션(-r) 을 모든 타입들에서도 사용 될 수 있도록 수정.

## 특이 사항

- report의 경우 현재 log type 에서만 지원하도록 되어 있으므로, 지원 범위를 다른 타입들까지 확장할지에 대한 여부와 그렇게 해야된다면 추가 이슈 작성이 필요로 합니다.