### PR TITLE
Fix formatting and Clippy warnings for Rust 1.81

### DIFF
--- a/src/migration/tests.rs
+++ b/src/migration/tests.rs
@@ -136,7 +136,8 @@ fn giganto_smb() {
 
 #[test]
 fn giganto_nfs() {
-    let data = "1614130373.991064000	localhost	192.168.0.111	58459	192.168.0.7	49670	0	0.000000000	-	-";
+    let data =
+        "1614130373.991064000	localhost	192.168.0.111	58459	192.168.0.7	49670	0	0.000000000	-	-";
 
     let rec = stringrecord(data);
 

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -187,7 +187,7 @@ fn build_query(event_code: &str, start: &str, end: &str, size: usize, last: u64)
 /// Send a query with `_search` option.
 async fn send_request(client: &Client, query: &Value, url: &str, index: &str) -> Result<Value> {
     client
-        .post(&format!("{url}/{index}/_search"))
+        .post(format!("{url}/{index}/_search"))
         .json(query)
         .send()
         .await?


### PR DESCRIPTION
This PR addresses formatting issues and Clippy warnings in the codebase to ensure compatibility with Rust 1.81. The changes include reformatting a long string in `src/migration/tests.rs` and removing unnecessary `&` in `src/syslog.rs`.

These changes should not affect the functionality of the code.