### PR TITLE
Resolve Clippy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,50 +6,50 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - name: Install libraries
-      run: sudo apt-get install libhyperscan-dev libpcap-dev
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: stable
-    - uses: actions/checkout@v2
-    - name: Check formatting
-      run: cargo fmt -- --check --config group_imports=StdExternalCrate
-    - name: Clippy
-      run: cargo clippy -- -D warnings -W clippy::pedantic
-    - name: Detect Cargo.lock changes
-      run: git diff-index --quiet HEAD --
-    - name: markdownlint
-      uses: articulate/actions-markdownlint@v1
+      - name: Install libraries
+        run: sudo apt-get install libhyperscan-dev libpcap-dev
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - uses: actions/checkout@v2
+      - name: Check formatting
+        run: cargo fmt -- --check --config group_imports=StdExternalCrate
+      - name: Clippy
+        run: cargo clippy --tests -- -D warnings -W clippy::pedantic
+      - name: Detect Cargo.lock changes
+        run: git diff-index --quiet HEAD --
+      - name: markdownlint
+        uses: articulate/actions-markdownlint@v1
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Install libraries
-      run: sudo apt-get install libhyperscan-dev libpcap-dev
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: stable
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - name: Install libraries
+        run: sudo apt-get install libhyperscan-dev libpcap-dev
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
 
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - name: Install libraries
-      run: sudo apt-get install libhyperscan-dev libpcap-dev
-    - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: stable
-    - uses: actions/checkout@v2
-    - name: Install Tarpaulin
-      run: cargo install cargo-tarpaulin --version 0.18.0-alpha3
-    - name: Generate coverage report
-      run: cargo tarpaulin --out xml --avoid-cfg-tarpaulin
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      - name: Install libraries
+        run: sudo apt-get install libhyperscan-dev libpcap-dev
+      - name: Install Rust
+        uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: stable
+      - uses: actions/checkout@v2
+      - name: Install Tarpaulin
+        run: cargo install cargo-tarpaulin --version 0.18.0-alpha3
+      - name: Generate coverage report
+        run: cargo tarpaulin --out xml --avoid-cfg-tarpaulin
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -121,7 +121,7 @@ impl Controller {
         loop {
             let mut files = files_in_dir(
                 &self.config.common.input,
-                &dir_option.file_prefix,
+                dir_option.file_prefix.as_deref(),
                 &processed,
             );
             if files.is_empty() {
@@ -159,7 +159,7 @@ impl Controller {
         };
         let dir = crate::syslog::fetch_elastic_search(elastic).await?;
 
-        let mut files = files_in_dir(&dir, &None, &[]);
+        let mut files = files_in_dir(&dir, None, &[]);
         if files.is_empty() {
             bail!("no data with elastic");
         }
@@ -348,7 +348,7 @@ fn file_to_kind(path: &Path) -> &'static str {
     }
 }
 
-fn files_in_dir(path: &str, prefix: &Option<String>, skip: &[PathBuf]) -> Vec<PathBuf> {
+fn files_in_dir(path: &str, prefix: Option<&str>, skip: &[PathBuf]) -> Vec<PathBuf> {
     WalkDir::new(path)
         .follow_links(true)
         .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ ARG:
 ";
 
 #[tokio::main]
-pub async fn main() -> Result<()> {
+async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     let config_filename = parse();
     let config = Config::new(config_filename.as_ref())?;

--- a/src/operation_log.rs
+++ b/src/operation_log.rs
@@ -94,16 +94,16 @@ mod tests {
         assert_eq!(res_info.agent_name, "agent".to_string());
         assert!(matches!(res_info.log_level, OpLogLevel::Info));
         assert_eq!(res_info.contents, "infolog".to_string());
-        assert_eq!(res_info.sensor, "".to_string());
+        assert_eq!(res_info.sensor, String::new());
 
         assert_eq!(res_warn.agent_name, "agent".to_string());
         assert!(matches!(res_warn.log_level, OpLogLevel::Warn));
         assert_eq!(res_warn.contents, "warnlog".to_string());
-        assert_eq!(res_warn.sensor, "".to_string());
+        assert_eq!(res_warn.sensor, String::new());
 
         assert_eq!(res_error.agent_name, "agent".to_string());
         assert!(matches!(res_error.log_level, OpLogLevel::Error));
         assert_eq!(res_error.contents, "errorlog".to_string());
-        assert_eq!(res_error.sensor, "".to_string());
+        assert_eq!(res_error.sensor, String::new());
     }
 }

--- a/src/security_log.rs
+++ b/src/security_log.rs
@@ -326,22 +326,22 @@ mod tests {
     #[test]
     fn parse_ubuntu() {
         let logs = [
-            r#"Oct 12 00:00:04 safe-web-red systemd[1]: logrotate.service: Succeeded."#,
-            r#"Oct 12 00:00:04 safe-web-red systemd[1]: Finished Rotate log files."#,
-            r#"Oct 12 00:00:04 safe-web-red systemd[1]: man-db.service: Succeeded."#,
-            r#"Oct 12 00:00:04 safe-web-red systemd[1]: Finished Daily man-db regeneration."#,
-            r#"Oct 12 00:17:01 safe-web-red CRON[1497802]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)"#,
-            r#"Oct 12 01:17:01 safe-web-red CRON[1509996]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)"#,
-            r#"Oct 12 01:47:20 safe-web-red systemd[1]: Starting Ubuntu Advantage Timer for running repeated jobs..."#,
-            r#"Oct 12 01:47:21 safe-web-red systemd[1]: ua-timer.service: Succeeded."#,
-            r#"Oct 12 01:47:21 safe-web-red systemd[1]: Finished Ubuntu Advantage Timer for running repeated jobs."#,
-            r#"Oct 12 02:17:01 safe-web-red CRON[1522215]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)"#,
-            r#"Oct 12 03:10:01 safe-web-red CRON[1532988]: (root) CMD (test -e /run/systemd/system || SERVICE_MODE=1 /sbin/e2scrub_all -A -r)"#,
-            r#"Oct 12 03:17:01 safe-web-red CRON[1534414]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)"#,
-            r#"Oct 12 04:08:19 safe-web-red systemd[1]: Starting Message of the Day..."#,
-            r#"Oct 12 04:08:28 safe-web-red 50-motd-news[1544912]:  * Strictly confined Kubernetes makes edge and IoT secure. Learn how MicroK8s"#,
-            r#"Oct 12 04:08:28 safe-web-red 50-motd-news[1544912]:    just raised the bar for easy, resilient and secure K8s cluster deployment."#,
-            r#"Oct 12 04:08:28 safe-web-red 50-motd-news[1544912]:    https://ubuntu.com/engage/secure-kubernetes-at-the-edge"#,
+            r"Oct 12 00:00:04 safe-web-red systemd[1]: logrotate.service: Succeeded.",
+            r"Oct 12 00:00:04 safe-web-red systemd[1]: Finished Rotate log files.",
+            r"Oct 12 00:00:04 safe-web-red systemd[1]: man-db.service: Succeeded.",
+            r"Oct 12 00:00:04 safe-web-red systemd[1]: Finished Daily man-db regeneration.",
+            r"Oct 12 00:17:01 safe-web-red CRON[1497802]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)",
+            r"Oct 12 01:17:01 safe-web-red CRON[1509996]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)",
+            r"Oct 12 01:47:20 safe-web-red systemd[1]: Starting Ubuntu Advantage Timer for running repeated jobs...",
+            r"Oct 12 01:47:21 safe-web-red systemd[1]: ua-timer.service: Succeeded.",
+            r"Oct 12 01:47:21 safe-web-red systemd[1]: Finished Ubuntu Advantage Timer for running repeated jobs.",
+            r"Oct 12 02:17:01 safe-web-red CRON[1522215]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)",
+            r"Oct 12 03:10:01 safe-web-red CRON[1532988]: (root) CMD (test -e /run/systemd/system || SERVICE_MODE=1 /sbin/e2scrub_all -A -r)",
+            r"Oct 12 03:17:01 safe-web-red CRON[1534414]: (root) CMD (   cd / && run-parts --report /etc/cron.hourly)",
+            r"Oct 12 04:08:19 safe-web-red systemd[1]: Starting Message of the Day...",
+            r"Oct 12 04:08:28 safe-web-red 50-motd-news[1544912]:  * Strictly confined Kubernetes makes edge and IoT secure. Learn how MicroK8s",
+            r"Oct 12 04:08:28 safe-web-red 50-motd-news[1544912]:    just raised the bar for easy, resilient and secure K8s cluster deployment.",
+            r"Oct 12 04:08:28 safe-web-red 50-motd-news[1544912]:    https://ubuntu.com/engage/secure-kubernetes-at-the-edge",
         ];
 
         let info = SecurityLogInfo {


### PR DESCRIPTION
Remove the `pub` keyword from `main` function b/c it violates two Clippy rules: [missing_panics_doc](https://rust-lang.github.io/rust-clippy/master/index.html#missing_panics_doc), [missing_errors_doc](https://rust-lang.github.io/rust-clippy/master/index.html#missing_errors_doc).

Although it is possible to add the necessary documentation, the `main` function fundamentally doesn't need to be public.

Close: #551