### PR TITLE
Refactor config structure and parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Moved configuration fields from the nested `Common` struct to the top-level
+  `Config` struct and updated related code accordingly.
+
 ### Fixed
 
 - Fixed oplog transfer failure caused by checking outdated module names.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ the environment variable `NETFLOW_TEMPLATES_PATH`.
 
 - Below is a detailed breakdown of all available configuration fields.
 
-### [Common]
-
-- This section is required and must be configured properly for REproduce to
-  function.
-
 <!-- markdownlint-disable -->
 
 | Field                     | Description                                                                | Required | Default    |
@@ -106,7 +101,6 @@ the environment variable `NETFLOW_TEMPLATES_PATH`.
 - Sends a Zeek log file to the Giganto server, setting `kind` to `dns`.
 
   ```toml
-  [common]
   cert = "/opt/clumit/keys/reproduce_cert.pem"
   key = "/opt/clumit/keys/reproduce_key.pem"
   ca_certs = ["/opt/clumit/keys/manager_cert.pem"]
@@ -122,7 +116,6 @@ the environment variable `NETFLOW_TEMPLATES_PATH`.
   oplog.
 
   ```toml
-  [common]
   cert = "/opt/clumit/keys/reproduce_cert.pem"
   key = "/opt/clumit/keys/reproduce_key.pem"
   ca_certs = ["/opt/clumit/keys/manager_cert.pem"]
@@ -137,7 +130,6 @@ the environment variable `NETFLOW_TEMPLATES_PATH`.
 - Sends a previously exported Giganto file to the Giganto server.
 
   ```toml
-  [common]
   cert = "/opt/clumit/keys/reproduce_cert.pem"
   key = "/opt/clumit/keys/reproduce_key.pem"
   ca_certs = ["/opt/clumit/keys/manager_cert.pem"]
@@ -156,7 +148,6 @@ the environment variable `NETFLOW_TEMPLATES_PATH`.
   data kind as image_load.
 
   ```toml
-  [common]
   cert = "/opt/clumit/keys/reproduce_cert.pem"
   key = "/opt/clumit/keys/reproduce_key.pem"
   ca_certs = ["/opt/clumit/keys/manager_cert.pem"]
@@ -172,7 +163,6 @@ the environment variable `NETFLOW_TEMPLATES_PATH`.
   Giganto server.
 
   ```toml
-  [common]
   cert = "/opt/clumit/keys/reproduce_cert.pem"
   key = "/opt/clumit/keys/reproduce_key.pem"
   ca_certs = ["/opt/clumit/keys/manager_cert.pem"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,22 +16,6 @@ pub enum InputType {
     Dir,
     Elastic,
 }
-
-#[derive(Deserialize, Debug, Clone)]
-#[allow(unused)]
-pub struct Common {
-    pub cert: String,
-    pub key: String,
-    pub ca_certs: Vec<String>,
-    #[serde(deserialize_with = "deserialize_socket_addr")]
-    pub giganto_ingest_srv_addr: SocketAddr,
-    pub giganto_name: String,
-    pub kind: String,
-    pub input: String,
-    pub report: bool,
-    pub log_dir: Option<PathBuf>,
-}
-
 #[derive(Deserialize, Debug, Clone)]
 pub struct File {
     pub export_from_giganto: Option<bool>,
@@ -61,7 +45,17 @@ pub struct ElasticSearch {
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {
-    pub common: Common,
+    pub cert: String,
+    pub key: String,
+    pub ca_certs: Vec<String>,
+    #[serde(deserialize_with = "deserialize_socket_addr")]
+    pub giganto_ingest_srv_addr: SocketAddr,
+    pub giganto_name: String,
+    pub kind: String,
+    pub input: String,
+    pub report: bool,
+    pub log_dir: Option<PathBuf>,
+
     pub file: Option<File>,
     pub directory: Option<Directory>,
     pub elastic: Option<ElasticSearch>,
@@ -75,9 +69,9 @@ impl Config {
     /// Returns an error if it fails to parse the configuration file correctly or it runs out of parameters.
     pub fn new(path: &Path) -> Result<Self> {
         let config = config::Config::builder()
-            .set_default("common.kind", String::new())
+            .set_default("kind", String::new())
             .context("cannot set the default kind value")?
-            .set_default("common.report", DEFAULT_REPORT_MODE)
+            .set_default("report", DEFAULT_REPORT_MODE)
             .context("cannot set the default report value")?
             .set_default("file.polling_mode", DEFAULT_POLLING_MODE)
             .context("cannot set the default file polling mode value")?

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -80,7 +80,7 @@ impl Controller {
     ///
     /// Stream finish / Connection close error
     pub async fn run(&self) -> Result<()> {
-        let input_type = input_type(&self.config.common.input);
+        let input_type = input_type(&self.config.input);
 
         if input_type == InputType::Elastic {
             self.run_elastic().await?;
@@ -92,11 +92,11 @@ impl Controller {
                     self.run_split(&mut producer).await?;
                 }
                 InputType::Log => {
-                    let file_name = Path::new(&self.config.common.input).to_path_buf();
+                    let file_name = Path::new(&self.config.input).to_path_buf();
                     self.run_single(
                         file_name.as_ref(),
                         &mut producer,
-                        &self.config.common.kind.clone(),
+                        &self.config.kind.clone(),
                         false,
                     )
                     .await?;
@@ -120,7 +120,7 @@ impl Controller {
         };
         loop {
             let mut files = files_in_dir(
-                &self.config.common.input,
+                &self.config.input,
                 dir_option.file_prefix.as_deref(),
                 &processed,
             );
@@ -139,7 +139,7 @@ impl Controller {
                 self.run_single(
                     file.as_path(),
                     producer,
-                    &self.config.common.kind,
+                    &self.config.kind,
                     dir_option.polling_mode,
                 )
                 .await?;
@@ -211,7 +211,7 @@ impl Controller {
         let offset = if let Some(count_skip) = file.transfer_skip_count {
             count_skip
         } else if let Some(ref offset_suffix) = file.last_transfer_line_suffix {
-            let filename = self.config.common.input.clone() + "_" + offset_suffix;
+            let filename = self.config.input.clone() + "_" + offset_suffix;
             u64::try_from(read_offset(&filename))?
         } else {
             0
@@ -315,7 +315,7 @@ impl Controller {
 
         if let Some(ref offset_suffix) = file.last_transfer_line_suffix {
             if let Err(e) = write_offset(
-                &(self.config.common.input.clone() + "_" + offset_suffix),
+                &(self.config.input.clone() + "_" + offset_suffix),
                 last_line,
             ) {
                 warn!("cannot write to offset file: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ ARG:
 async fn main() -> Result<()> {
     let config_filename = parse();
     let config = Config::new(config_filename.as_ref())?;
-    let _guards = init_tracing(config.common.log_dir.as_deref())?;
+    let _guards = init_tracing(config.log_dir.as_deref())?;
     let controller = Controller::new(config);
     info!("reproduce start");
     let _handle = task::spawn(async move {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -75,11 +75,7 @@ impl Producer {
     ///
     /// Connection error, not `TimedOut`
     pub async fn new_giganto(config: &Config) -> Result<Self> {
-        let endpoint = match init_giganto(
-            &config.common.cert,
-            &config.common.key,
-            &config.common.ca_certs,
-        ) {
+        let endpoint = match init_giganto(&config.cert, &config.key, &config.ca_certs) {
             Ok(ret) => ret,
             Err(e) => {
                 bail!("failed to create Giganto producer: {:?}", e);
@@ -87,10 +83,7 @@ impl Producer {
         };
         loop {
             let conn = match endpoint
-                .connect(
-                    config.common.giganto_ingest_srv_addr,
-                    &config.common.giganto_name,
-                )?
+                .connect(config.giganto_ingest_srv_addr, &config.giganto_name)?
                 .await
             {
                 Ok(r) => r,
@@ -117,10 +110,10 @@ impl Producer {
             return Ok(Self {
                 giganto: Giganto {
                     giganto_endpoint: endpoint.clone(),
-                    giganto_server: config.common.giganto_ingest_srv_addr,
+                    giganto_server: config.giganto_ingest_srv_addr,
                     giganto_info: GigantoInfo {
-                        name: config.common.giganto_name.clone(),
-                        kind: config.common.kind.clone(),
+                        name: config.giganto_name.clone(),
+                        kind: config.kind.clone(),
                     },
                     giganto_conn: conn,
                     giganto_sender: giganto_send,

--- a/src/report.rs
+++ b/src/report.rs
@@ -41,7 +41,7 @@ impl Report {
     }
 
     pub fn start(&mut self) {
-        if !self.config.common.report {
+        if !self.config.report {
             return;
         }
 
@@ -49,7 +49,7 @@ impl Report {
     }
 
     pub fn process(&mut self, bytes: usize) {
-        if !self.config.common.report {
+        if !self.config.report {
             return;
         }
 
@@ -63,7 +63,7 @@ impl Report {
     }
 
     pub fn skip(&mut self, bytes: usize) {
-        if !self.config.common.report {
+        if !self.config.report {
             return;
         }
         self.skip_bytes += bytes;
@@ -77,12 +77,12 @@ impl Report {
     pub fn end(&mut self) -> io::Result<()> {
         const ARRANGE_VAR: usize = 28;
 
-        if !self.config.common.report {
+        if !self.config.report {
             return Ok(());
         }
 
         let report_dir = Path::new("/report");
-        let topic = format!("{}.report", &self.config.common.kind);
+        let topic = format!("{}.report", &self.config.kind);
         let report_path = if report_dir.is_dir() {
             report_dir.join(topic)
         } else {
@@ -108,8 +108,8 @@ impl Report {
             self.time_now,
             width = ARRANGE_VAR,
         ))?;
-        let input_type = input_type(&self.config.common.input);
-        let input = &&self.config.common.input;
+        let input_type = input_type(&self.config.input);
+        let input = &&self.config.input;
         let (header, processed_bytes) = match input_type {
             InputType::Log => {
                 // add 1 byte newline character per line

--- a/tests/config.toml
+++ b/tests/config.toml
@@ -1,4 +1,3 @@
-[common]
 cert = "tests/cert.pem"
 key = "tests/key.pem"
 ca_certs = ["tests/root.pem"]


### PR DESCRIPTION
Remove the nested `Common` struct from the `Config` struct and move its fields directly into the top-level `Config` struct to simplify configuration parsing. Update all related code and documentation accordingly.

Close: #570 