### PR TITLE
Fix oplog transfer failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed oplog transfer failure caused by checking outdated module names.
+
 ## [0.21.2] - 2025-03-14
 
 ### Added
@@ -373,6 +379,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   Docker, you should bind the `/report` to see the report file from the host.
 - Dockerfile changed to use g++-8
 
+[Unreleased]: https://github.com/aicers/reproduce/compare/0.21.2...main
 [0.21.2]: https://github.com/aicers/reproduce/compare/0.21.1...0.21.2
 [0.21.1]: https://github.com/aicers/reproduce/compare/0.21.0...0.21.1
 [0.21.0]: https://github.com/aicers/reproduce/compare/0.20.1...0.21.0

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -20,13 +20,13 @@ const GIGANTO_ZEEK_KINDS: [&str; 17] = [
     "ldap", "tls", "smb", "nfs", "bootp", "dhcp",
 ];
 const AGENTS_LIST: [&str; 7] = [
-    "review",
-    "giganto",
-    "piglet",
-    "hog",
-    "crusher",
-    "reconverge",
-    "tivan",
+    "manager",
+    "data_store",
+    "sensor",
+    "semi_supervised",
+    "time_series_generator",
+    "unsupervised",
+    "ti_container",
 ];
 const OPERATION_LOG: &str = "oplog";
 const SYSMON_KINDS: [&str; 14] = [


### PR DESCRIPTION
Close: #581 

Update `AGENTS_LIST` to reflect recent changes in module naming. Previously, the transfer logic verified module names by parsing log filenames and checking inclusion in a predefined list. Recent module naming updates caused mismatches, leading to oplog transfer failures. This commit resolves the issue by synchronizing the module name list with the updated log filename format.