### PR TITLE
Fix Clippy warnings caused by rustc 1.86.0

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -351,7 +351,7 @@ fn file_to_kind(path: &Path) -> Result<&str> {
             "26" => "file_delete_detected",
             _ => "",
         });
-    };
+    }
     Ok("")
 }
 

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -103,7 +103,7 @@ pub async fn fetch_elastic_search(elasticsearch: &ElasticSearch) -> Result<Strin
                             "26" => process_event_data::<ElasticFileDeleteDetected>(
                                 data, &file_name, size,
                             ),
-                            _ => continue,
+                            _ => {}
                         }
                     }
                 }


### PR DESCRIPTION
## Related Issues
closes #586 
## PR Description
- Removed unnecessary continue statements inside loops to comply with Clippy's `needless_continue` lint introduced in Rust 1.86.0.

- If explicit continue is preferred for readability, it can be allowed by adding `#[allow(clippy::needless_continue)]`.