### PR TITLE
Replace log_dir with log_path in configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[env]
-LOG_FILENAME = "data_broker.log"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Moved configuration fields from the nested `Common` struct to the top-level
   `Config` struct and updated related code accordingly.
+- Replaced `log_dir` with `log_path` in command line arguments. Now the log file
+  path can be specified directly rather than combining a directory and a fixed
+  filename.
+- Removed dependency on LOG_FILENAME environment variable by eliminating the
+  .cargo/config.toml file.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ the environment variable `NETFLOW_TEMPLATES_PATH`.
 | `kind`                    | Type of data being processed (See [Defined kind type](#defined-kind-type)) | No       | "" (empty) |
 | `input`                   | Specifies the input source: file, directory, or elastic                    | Yes      | -          |
 | `report`                  | Enables or disables reporting of transfer statistics                       | No       | false      |
-| `log_dir`                 | Directory for log files. If not specified, logs are sent to stdout.        | No       | -          |
+| `log_path`                | Path to the log file. If not specified, logs are sent to stdout.           | No       | -          |
 
 <!-- markdownlint-enable -->
-
-- `log_dir`: The log file is named data_broker.log.
 
 ### [File]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,7 @@ pub struct Config {
     pub(super) kind: String,
     pub(super) input: String,
     pub(super) report: bool,
-    pub log_dir: Option<PathBuf>,
+    pub log_path: Option<PathBuf>,
 
     pub(super) file: Option<File>,
     pub(super) directory: Option<Directory>,


### PR DESCRIPTION
## Related Issues
closes #583

## PR Description
This PR replaces the `log_dir` configuration field with `log_path` in the reproduce project. This change allows users to specify the full log file path directly rather than combining a directory with a fixed filename.

Changes include:
- Rename `log_dir` to `log_path` in Config struct
- Update init_tracing function to use file path directly
- Remove .cargo/config.toml file containing LOG_FILENAME environment variable
- Update documentation in README.md to reflect these changes
- Update CHANGELOG.md with appropriate entries

## Special Notes
After merging, please inform users about this breaking change since it modifies the configuration file format.