### PR TITLE
Use `pub(crate)` for crate-wide item visibility

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,54 +11,54 @@ const DEFAULT_POLLING_MODE: bool = false;
 const DEFAULT_EXPORT_FROM_GIGANTO: bool = false;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum InputType {
+pub(crate) enum InputType {
     Log,
     Dir,
     Elastic,
 }
 #[derive(Deserialize, Debug, Clone)]
-pub(super) struct File {
-    pub(super) export_from_giganto: Option<bool>,
-    pub(super) polling_mode: bool,
-    pub(super) transfer_count: Option<u64>,
-    pub(super) transfer_skip_count: Option<u64>,
-    pub(super) last_transfer_line_suffix: Option<String>,
+pub(crate) struct File {
+    pub(crate) export_from_giganto: Option<bool>,
+    pub(crate) polling_mode: bool,
+    pub(crate) transfer_count: Option<u64>,
+    pub(crate) transfer_skip_count: Option<u64>,
+    pub(crate) last_transfer_line_suffix: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub(super) struct Directory {
-    pub(super) file_prefix: Option<String>,
-    pub(super) polling_mode: bool,
+pub(crate) struct Directory {
+    pub(crate) file_prefix: Option<String>,
+    pub(crate) polling_mode: bool,
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub(super) struct ElasticSearch {
-    pub(super) url: String,
-    pub(super) event_codes: Vec<String>,
-    pub(super) indices: Vec<String>,
-    pub(super) start_time: String,
-    pub(super) end_time: String,
-    pub(super) size: usize,
-    pub(super) dump_dir: String,
-    pub(super) elastic_auth: String,
+pub(crate) struct ElasticSearch {
+    pub(crate) url: String,
+    pub(crate) event_codes: Vec<String>,
+    pub(crate) indices: Vec<String>,
+    pub(crate) start_time: String,
+    pub(crate) end_time: String,
+    pub(crate) size: usize,
+    pub(crate) dump_dir: String,
+    pub(crate) elastic_auth: String,
 }
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct Config {
-    pub(super) cert: String,
-    pub(super) key: String,
-    pub(super) ca_certs: Vec<String>,
+pub(crate) struct Config {
+    pub(crate) cert: String,
+    pub(crate) key: String,
+    pub(crate) ca_certs: Vec<String>,
     #[serde(deserialize_with = "deserialize_socket_addr")]
-    pub(super) giganto_ingest_srv_addr: SocketAddr,
-    pub(super) giganto_name: String,
-    pub(super) kind: String,
-    pub(super) input: String,
-    pub(super) report: bool,
-    pub log_path: Option<PathBuf>,
+    pub(crate) giganto_ingest_srv_addr: SocketAddr,
+    pub(crate) giganto_name: String,
+    pub(crate) kind: String,
+    pub(crate) input: String,
+    pub(crate) report: bool,
+    pub(crate) log_path: Option<PathBuf>,
 
-    pub(super) file: Option<File>,
-    pub(super) directory: Option<Directory>,
-    pub(super) elastic: Option<ElasticSearch>,
+    pub(crate) file: Option<File>,
+    pub(crate) directory: Option<Directory>,
+    pub(crate) elastic: Option<ElasticSearch>,
 }
 
 impl Config {
@@ -67,7 +67,7 @@ impl Config {
     /// # Errors
     ///
     /// Returns an error if it fails to parse the configuration file correctly or it runs out of parameters.
-    pub fn new(path: &Path) -> Result<Self> {
+    pub(crate) fn new(path: &Path) -> Result<Self> {
         let config = config::Config::builder()
             .set_default("kind", String::new())
             .context("cannot set the default kind value")?

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -62,13 +62,13 @@ const SUPPORTED_SECURITY_KIND: [&str; 13] = [
     "nginx_accesslog_1.25.2",
 ];
 
-pub struct Controller {
+pub(crate) struct Controller {
     config: Config,
 }
 
 impl Controller {
     #[must_use]
-    pub fn new(config: Config) -> Self {
+    pub(crate) fn new(config: Config) -> Self {
         Self { config }
     }
 
@@ -79,7 +79,7 @@ impl Controller {
     /// # Panics
     ///
     /// Stream finish / Connection close error
-    pub async fn run(&self) -> Result<()> {
+    pub(crate) async fn run(&self) -> Result<()> {
         let input_type = input_type(&self.config.input);
 
         if input_type == InputType::Elastic {
@@ -384,7 +384,7 @@ fn files_in_dir(path: &str, prefix: Option<&str>, skip: &[PathBuf]) -> Vec<PathB
         .collect()
 }
 
-pub(super) fn input_type(input: &str) -> InputType {
+pub(crate) fn input_type(input: &str) -> InputType {
     if input == "elastic" {
         InputType::Elastic
     } else {

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use csv::StringRecord;
 
-pub(super) trait TryFromGigantoRecord: Sized {
+pub(crate) trait TryFromGigantoRecord: Sized {
     fn try_from_giganto_record(rec: &StringRecord) -> Result<(Self, i64)>;
 }
 

--- a/src/netflow.rs
+++ b/src/netflow.rs
@@ -12,7 +12,7 @@ pub(super) use statistics::{ProcessStats, Stats};
 pub(super) use templates::TemplatesBox;
 use tracing::{error, warn};
 
-pub(super) trait ParseNetflowDatasets: Sized {
+pub(crate) trait ParseNetflowDatasets: Sized {
     fn parse_netflow_datasets(
         pkt_cnt: u64,
         templates: &mut TemplatesBox,

--- a/src/netflow/packet.rs
+++ b/src/netflow/packet.rs
@@ -160,7 +160,7 @@ impl PktBuf {
         }
     }
 
-    pub(super) fn src_addr(&self) -> IpAddr {
+    pub(crate) fn src_addr(&self) -> IpAddr {
         self.iph.addr_pair.src
     }
 

--- a/src/operation_log.rs
+++ b/src/operation_log.rs
@@ -27,7 +27,7 @@ fn parse_log_level(level: &str) -> Result<OpLogLevel> {
     }
 }
 
-pub(super) fn log_regex(line: &str, agent: &str) -> Result<(OpLog, i64)> {
+pub(crate) fn log_regex(line: &str, agent: &str) -> Result<(OpLog, i64)> {
     let caps = get_log_regex().captures(line).context("invalid log line")?;
 
     let log_level = match caps.name("level") {

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -62,8 +62,8 @@ const INTERVAL: u64 = 5;
 const BATCH_SIZE: usize = 100;
 
 #[allow(clippy::large_enum_variant)]
-pub(super) struct Producer {
-    pub(super) giganto: Giganto,
+pub(crate) struct Producer {
+    pub(crate) giganto: Giganto,
 }
 
 impl Producer {
@@ -74,7 +74,7 @@ impl Producer {
     ///  # Panics
     ///
     /// Connection error, not `TimedOut`
-    pub(super) async fn new_giganto(config: &Config) -> Result<Self> {
+    pub(crate) async fn new_giganto(config: &Config) -> Result<Self> {
         let endpoint = match init_giganto(&config.cert, &config.key, &config.ca_certs) {
             Ok(ret) => ret,
             Err(e) => {
@@ -128,7 +128,7 @@ impl Producer {
     ///
     /// Returns an error if any writing operation fails.
     #[allow(clippy::too_many_lines)]
-    pub(super) async fn send_raw_to_giganto(
+    pub(crate) async fn send_raw_to_giganto(
         &mut self,
         iter: StringRecordsIntoIter<File>,
         skip: u64,
@@ -588,7 +588,7 @@ impl Producer {
     /// # Errors
     ///
     /// Returns an error if any writing operation fails.
-    pub(super) async fn send_oplog_to_giganto(
+    pub(crate) async fn send_oplog_to_giganto(
         &mut self,
         reader: BufReader<File>,
         agent: &str,
@@ -617,7 +617,7 @@ impl Producer {
     ///
     /// Returns an error if any writing operation fails.
     #[allow(clippy::too_many_lines)]
-    pub(super) async fn send_sysmon_to_giganto(
+    pub(crate) async fn send_sysmon_to_giganto(
         &mut self,
         iter: StringRecordsIntoIter<File>,
         skip: u64,
@@ -832,7 +832,7 @@ impl Producer {
     /// # Errors
     ///
     /// Returns an error if it failed to parse netflow pcap.
-    pub(super) async fn send_netflow_to_giganto(
+    pub(crate) async fn send_netflow_to_giganto(
         &mut self,
         filename: &Path,
         skip: u64,
@@ -873,7 +873,7 @@ impl Producer {
     ///
     /// Returns an error if any writing operation fails.
     #[allow(clippy::too_many_lines)]
-    pub(super) async fn send_seculog_to_giganto(
+    pub(crate) async fn send_seculog_to_giganto(
         &mut self,
         reader: BufReader<File>,
         file_polling_mode: bool,
@@ -1060,7 +1060,7 @@ impl Producer {
     /// # Errors
     ///
     /// Returns an error if any writing log fails.
-    pub(super) async fn send_log_to_giganto(
+    pub(crate) async fn send_log_to_giganto(
         &mut self,
         file_name: &Path,
         file_polling_mode: bool,
@@ -1085,7 +1085,7 @@ impl Producer {
 }
 
 #[derive(Debug)]
-pub(super) struct Giganto {
+pub(crate) struct Giganto {
     giganto_endpoint: Endpoint,
     giganto_server: SocketAddr,
     giganto_info: GigantoInfo,
@@ -1826,7 +1826,7 @@ impl Giganto {
         Ok(())
     }
 
-    pub(super) async fn finish(&mut self) -> Result<()> {
+    pub(crate) async fn finish(&mut self) -> Result<()> {
         self.send_finish().await?;
         let mut force_finish_count = 0;
         loop {

--- a/src/report.rs
+++ b/src/report.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Duration, Utc};
 use crate::controller::input_type;
 use crate::{Config, InputType};
 
-pub(super) struct Report {
+pub(crate) struct Report {
     config: Config,
     sum_bytes: usize,
     min_bytes: usize,
@@ -24,7 +24,7 @@ pub(super) struct Report {
 
 impl Report {
     #[must_use]
-    pub(super) fn new(config: Config) -> Self {
+    pub(crate) fn new(config: Config) -> Self {
         Report {
             config,
             sum_bytes: 0,
@@ -40,7 +40,7 @@ impl Report {
         }
     }
 
-    pub(super) fn start(&mut self) {
+    pub(crate) fn start(&mut self) {
         if !self.config.report {
             return;
         }
@@ -48,7 +48,7 @@ impl Report {
         self.time_start = Utc::now();
     }
 
-    pub(super) fn process(&mut self, bytes: usize) {
+    pub(crate) fn process(&mut self, bytes: usize) {
         if !self.config.report {
             return;
         }
@@ -75,7 +75,7 @@ impl Report {
     ///
     /// * `io::Error` when writing to the report file fails.
     #[allow(clippy::too_many_lines)]
-    pub(super) fn end(&mut self) -> io::Result<()> {
+    pub(crate) fn end(&mut self) -> io::Result<()> {
         const ARRANGE_VAR: usize = 28;
 
         if !self.config.report {

--- a/src/security_log.rs
+++ b/src/security_log.rs
@@ -27,14 +27,14 @@ const DEFAULT_PORT: u16 = 0;
 const DEFAULT_IPADDR: IpAddr = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
 #[derive(Debug, Clone)]
-pub(super) struct SecurityLogInfo {
+pub(crate) struct SecurityLogInfo {
     kind: String,
     log_type: String,
     version: String,
 }
 
 impl SecurityLogInfo {
-    pub(super) fn new(giganto_kind: &str) -> SecurityLogInfo {
+    pub(crate) fn new(giganto_kind: &str) -> SecurityLogInfo {
         let info: Vec<&str> = giganto_kind.split('_').collect();
         let msg =
             "verified by `match` expression in the `Producer::send_seculog_to_giganto` method.";
@@ -47,45 +47,45 @@ impl SecurityLogInfo {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Wapples;
+pub(crate) struct Wapples;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Mf2;
+pub(crate) struct Mf2;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct SniperIps;
+pub(crate) struct SniperIps;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Aiwaf;
+pub(crate) struct Aiwaf;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Tg;
+pub(crate) struct Tg;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Vforce;
+pub(crate) struct Vforce;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Srx;
+pub(crate) struct Srx;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct SonicWall;
+pub(crate) struct SonicWall;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Fgt;
+pub(crate) struct Fgt;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct ShadowWall;
+pub(crate) struct ShadowWall;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Axgate;
+pub(crate) struct Axgate;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Ubuntu;
+pub(crate) struct Ubuntu;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub(super) struct Nginx;
+pub(crate) struct Nginx;
 
-pub(super) trait ParseSecurityLog {
+pub(crate) trait ParseSecurityLog {
     fn parse_security_log(line: &str, serial: i64, info: SecurityLogInfo)
         -> Result<(SecuLog, i64)>; // agent: &str
 }

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -46,7 +46,7 @@ use self::{
 use crate::config::ElasticSearch;
 
 #[allow(clippy::unused_async)]
-pub(super) async fn fetch_elastic_search(elasticsearch: &ElasticSearch) -> Result<String> {
+pub(crate) async fn fetch_elastic_search(elasticsearch: &ElasticSearch) -> Result<String> {
     let now = Utc::now();
     let exec_time = format!("{}", now.format("%F %T"));
 
@@ -241,7 +241,7 @@ fn parse_sysmon_time(time: &str) -> Result<DateTime<Utc>> {
     }
 }
 
-pub(super) fn open_sysmon_csv_file(path: &Path) -> Result<Reader<File>> {
+pub(crate) fn open_sysmon_csv_file(path: &Path) -> Result<Reader<File>> {
     Ok(ReaderBuilder::new()
         .comment(Some(b'#'))
         .delimiter(b'\t')
@@ -249,7 +249,7 @@ pub(super) fn open_sysmon_csv_file(path: &Path) -> Result<Reader<File>> {
         .from_path(path)?)
 }
 
-pub(super) trait TryFromSysmonRecord: Sized {
+pub(crate) trait TryFromSysmonRecord: Sized {
     fn try_from_sysmon_record(rec: &StringRecord, serial: i64) -> Result<(Self, i64)>;
 }
 

--- a/src/syslog/dns_query.rs
+++ b/src/syslog/dns_query.rs
@@ -87,7 +87,7 @@ impl TryFromSysmonRecord for DnsEvent {
 }
 
 #[derive(Serialize)]
-pub(super) struct ElasticDnsEvent {
+pub(crate) struct ElasticDnsEvent {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/file_create.rs
+++ b/src/syslog/file_create.rs
@@ -79,7 +79,7 @@ impl TryFromSysmonRecord for FileCreate {
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Serialize)]
-pub(super) struct ElasticFileCreate {
+pub(crate) struct ElasticFileCreate {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/file_create_stream_hash.rs
+++ b/src/syslog/file_create_stream_hash.rs
@@ -89,7 +89,7 @@ impl TryFromSysmonRecord for FileCreateStreamHash {
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Serialize)]
-pub(super) struct ElasticFileCreateStreamHash {
+pub(crate) struct ElasticFileCreateStreamHash {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/file_create_time.rs
+++ b/src/syslog/file_create_time.rs
@@ -82,7 +82,7 @@ impl TryFromSysmonRecord for FileCreationTimeChanged {
 }
 
 #[derive(Serialize)]
-pub(super) struct ElasticFileCreationTimeChanged {
+pub(crate) struct ElasticFileCreationTimeChanged {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/file_delete.rs
+++ b/src/syslog/file_delete.rs
@@ -100,7 +100,7 @@ impl TryFromSysmonRecord for FileDelete {
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Serialize)]
-pub(super) struct ElasticFileDelete {
+pub(crate) struct ElasticFileDelete {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/file_delete_detected.rs
+++ b/src/syslog/file_delete_detected.rs
@@ -88,7 +88,7 @@ impl TryFromSysmonRecord for FileDeleteDetected {
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Serialize)]
-pub(super) struct ElasticFileDeleteDetected {
+pub(crate) struct ElasticFileDeleteDetected {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/image_load.rs
+++ b/src/syslog/image_load.rs
@@ -130,7 +130,7 @@ impl TryFromSysmonRecord for ImageLoaded {
 }
 
 #[derive(Serialize)]
-pub(super) struct ElasticImageLoaded {
+pub(crate) struct ElasticImageLoaded {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/network_connect.rs
+++ b/src/syslog/network_connect.rs
@@ -173,7 +173,7 @@ impl TryFromSysmonRecord for NetworkConnection {
 }
 
 #[derive(Serialize)]
-pub(super) struct ElasticNetworkConnection {
+pub(crate) struct ElasticNetworkConnection {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/pipe_event.rs
+++ b/src/syslog/pipe_event.rs
@@ -73,7 +73,7 @@ impl TryFromSysmonRecord for PipeEvent {
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Serialize)]
-pub(super) struct ElasticPipeEvent {
+pub(crate) struct ElasticPipeEvent {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/process_create.rs
+++ b/src/syslog/process_create.rs
@@ -183,7 +183,7 @@ impl TryFromSysmonRecord for ProcessCreate {
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Serialize)]
-pub(super) struct ElasticProcessCreate {
+pub(crate) struct ElasticProcessCreate {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/process_tamper.rs
+++ b/src/syslog/process_tamper.rs
@@ -67,7 +67,7 @@ impl TryFromSysmonRecord for ProcessTampering {
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Serialize)]
-pub(super) struct ElasticProcessTampering {
+pub(crate) struct ElasticProcessTampering {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/process_terminate.rs
+++ b/src/syslog/process_terminate.rs
@@ -60,7 +60,7 @@ impl TryFromSysmonRecord for ProcessTerminated {
 }
 
 #[derive(Serialize)]
-pub(super) struct ElasticProcessTerminated {
+pub(crate) struct ElasticProcessTerminated {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/registry_key_rename.rs
+++ b/src/syslog/registry_key_rename.rs
@@ -78,7 +78,7 @@ impl TryFromSysmonRecord for RegistryKeyValueRename {
 }
 
 #[derive(Serialize)]
-pub(super) struct ElasticRegistryKeyValueRename {
+pub(crate) struct ElasticRegistryKeyValueRename {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/syslog/registry_value_set.rs
+++ b/src/syslog/registry_value_set.rs
@@ -79,7 +79,7 @@ impl TryFromSysmonRecord for RegistryValueSet {
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Serialize)]
-pub(super) struct ElasticRegistryValueSet {
+pub(crate) struct ElasticRegistryValueSet {
     agent_name: Option<String>,
     agent_id: Option<String>,
     event_action: Option<String>,

--- a/src/zeek.rs
+++ b/src/zeek.rs
@@ -12,7 +12,7 @@ const PROTO_TCP: u8 = 0x06;
 const PROTO_UDP: u8 = 0x11;
 const PROTO_ICMP: u8 = 0x01;
 
-pub(super) trait TryFromZeekRecord: Sized {
+pub(crate) trait TryFromZeekRecord: Sized {
     fn try_from_zeek_record(rec: &StringRecord) -> Result<(Self, i64)>;
 }
 
@@ -31,7 +31,7 @@ fn parse_zeek_timestamp(timestamp: &str) -> Result<DateTime<Utc>> {
     }
 }
 
-pub(super) fn open_raw_event_log_file(path: &Path) -> Result<Reader<File>> {
+pub(crate) fn open_raw_event_log_file(path: &Path) -> Result<Reader<File>> {
     Ok(ReaderBuilder::new()
         .comment(Some(b'#'))
         .delimiter(b'\t')


### PR DESCRIPTION
Closes #582
Replaced `pub(super)` with `pub(crate)` across the repository where items are intended to be accessed throughout the crate.