### PR TITLE
Refactor log messages for consistency and clarity

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -8,7 +8,7 @@ use std::sync::{
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use walkdir::WalkDir;
 
 use crate::syslog::open_sysmon_csv_file;
@@ -129,13 +129,13 @@ impl Controller {
                     tokio::time::sleep(Duration::from_millis(10_000)).await;
                     continue;
                 }
-                error!("no input file");
+                error!("No input file");
                 break;
             }
 
             files.sort_unstable();
             for file in files {
-                info!("{file:?}");
+                info!("File: {file:?}");
                 self.run_single(
                     file.as_path(),
                     producer,
@@ -167,7 +167,7 @@ impl Controller {
         files.sort_unstable();
         for file in files {
             let mut producer = producer(&self.config).await;
-            info!("{file:?}");
+            info!("File: {file:?}");
             let kind = file_to_kind(&file)?;
             self.run_single(file.as_path(), &mut producer, kind, false)
                 .await?;
@@ -318,7 +318,7 @@ impl Controller {
                 &(self.config.input.clone() + "_" + offset_suffix),
                 last_line,
             ) {
-                warn!("cannot write to offset file: {e}");
+                warn!("Cannot write to offset file: {e}");
             }
         }
         Ok(())
@@ -402,7 +402,7 @@ fn read_offset(filename: &str) -> usize {
         let mut content = String::new();
         if f.read_to_string(&mut content).is_ok() {
             if let Ok(offset) = content.parse() {
-                info!("offset file found. Skipping {offset} entries.");
+                info!("Found offset file, skipping {offset} entries");
                 return offset;
             }
         }
@@ -417,11 +417,11 @@ fn write_offset(filename: &str, offset: u64) -> Result<()> {
 }
 
 async fn producer(config: &Config) -> Producer {
-    info!("output type=GIGANTO");
+    debug!("output type=GIGANTO");
     match Producer::new_giganto(config).await {
         Ok(p) => p,
         Err(e) => {
-            error!("cannot create Giganto producer: {e}");
+            error!("Cannot create producer: {e}");
             std::process::exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,15 +44,15 @@ async fn main() -> Result<()> {
     let config = Config::new(config_filename.as_ref())?;
     let _guard = init_tracing(config.log_path.as_deref())?;
     let controller = Controller::new(config);
-    info!("reproduce start");
+    info!("Data Broker started");
     let _handle = task::spawn(async move {
         if let Err(e) = controller.run().await {
-            error!("ERROR: {e}");
+            error!("Terminated with error: {e}");
             std::process::exit(1);
         }
     })
     .await;
-    info!("reproduce end");
+    info!("Data Broker completed");
     Ok(())
 }
 

--- a/src/netflow.rs
+++ b/src/netflow.rs
@@ -10,7 +10,7 @@ use giganto_client::ingest::netflow::{Netflow5, Netflow9};
 pub(super) use packet::{NetflowHeader, PktBuf};
 pub(super) use statistics::{ProcessStats, Stats};
 pub(super) use templates::TemplatesBox;
-use tracing::{error, warn};
+use tracing::warn;
 
 pub(crate) trait ParseNetflowDatasets: Sized {
     fn parse_netflow_datasets(
@@ -121,7 +121,7 @@ impl ParseNetflowDatasets for Netflow9 {
                     }
                     stats.add(ProcessStats::Events, usize::from(header.count));
                 } else {
-                    error!("no template for flow key ({:?})", flow_key);
+                    warn!("No template for flow key ({:?})", flow_key);
                     stats.add(ProcessStats::TemplateNotFound, 1);
                 }
             }

--- a/src/netflow/templates.rs
+++ b/src/netflow/templates.rs
@@ -109,7 +109,7 @@ impl TemplatesBox {
             let key = (src_addr, tmpl.header.source_id, tmpl.template_id);
             if self.templates.insert(key, tmpl.clone()).is_none() {
                 info!(
-                    "packet #{}: New template {:?} is appended. {}",
+                    "Packet #{}: New template {:?} is appended: {}",
                     pkt_cnt, key, tmpl
                 );
             }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -88,7 +88,7 @@ impl Producer {
             {
                 Ok(r) => r,
                 Err(quinn::ConnectionError::TimedOut) => {
-                    info!("server timeout, reconnecting...");
+                    info!("Server timeout, reconnecting...");
                     tokio::time::sleep(Duration::from_secs(INTERVAL)).await;
                     continue;
                 }
@@ -1116,7 +1116,7 @@ impl Giganto {
     where
         T: Serialize + TryFromZeekRecord + Unpin + Debug,
     {
-        info!("send zeek");
+        info!("Send zeek");
         let mut success_cnt = 0u64;
         let mut failed_cnt = 0u64;
         let mut pos = Position::new();
@@ -1161,7 +1161,7 @@ impl Giganto {
                             }
                             Err(e) => {
                                 failed_cnt += 1;
-                                error!("failed to convert data #{}: {e}", next_pos.line());
+                                warn!("Failed to convert data #{}: {e}", next_pos.line());
                             }
                         }
                     }
@@ -1170,7 +1170,7 @@ impl Giganto {
                     }
                     Err(e) => {
                         failed_cnt += 1;
-                        error!("invalid record: {e}");
+                        warn!("Invalid record: {e}");
                     }
                 }
                 pos = next_pos;
@@ -1193,14 +1193,14 @@ impl Giganto {
         }
 
         info!(
-            "last line: {}, success line: {}, failed line: {} ",
+            "Last line: {}, Success: {}, Failed: {}",
             pos.line(),
             success_cnt,
             failed_cnt
         );
 
         if let Err(e) = report.end() {
-            warn!("cannot write report: {e}");
+            warn!("Cannot write report: {e}");
         }
 
         Ok(pos.line())
@@ -1220,7 +1220,7 @@ impl Giganto {
     where
         T: Serialize + TryFromGigantoRecord + Unpin + Debug,
     {
-        info!("migration");
+        info!("Migration");
         let mut success_cnt = 0u64;
         let mut failed_cnt = 0u64;
         let mut pos = Position::new();
@@ -1265,7 +1265,7 @@ impl Giganto {
                             }
                             Err(e) => {
                                 failed_cnt += 1;
-                                error!("failed to convert data #{}: {e}", next_pos.line());
+                                warn!("Failed to convert data #{}: {e}", next_pos.line());
                             }
                         }
                     }
@@ -1274,7 +1274,7 @@ impl Giganto {
                     }
                     Err(e) => {
                         failed_cnt += 1;
-                        error!("invalid record: {e}");
+                        warn!("Invalid record: {e}");
                     }
                 }
                 pos = next_pos;
@@ -1297,14 +1297,14 @@ impl Giganto {
         }
 
         info!(
-            "last line: {}, success line: {}, failed line: {} ",
+            "Last line: {}, Success: {}, Failed: {}",
             pos.line(),
             success_cnt,
             failed_cnt
         );
 
         if let Err(e) = report.end() {
-            warn!("cannot write report: {e}");
+            warn!("Cannot write report: {e}");
         }
 
         Ok(pos.line())
@@ -1321,7 +1321,7 @@ impl Giganto {
         running: Arc<AtomicBool>,
         report: &mut Report,
     ) -> Result<u64> {
-        info!("send oplog");
+        info!("Send oplog");
         let mut lines = reader.lines();
         let mut cnt = 0;
         let mut success_cnt = 0u64;
@@ -1382,12 +1382,12 @@ impl Giganto {
         }
 
         info!(
-            "last line: {}, success: {}, failed: {}",
+            "Last line: {}, Success: {}, Failed: {}",
             cnt, success_cnt, failed_cnt
         );
 
         if let Err(e) = report.end() {
-            warn!("cannot write report: {e}");
+            warn!("Cannot write report: {e}");
         }
 
         Ok(cnt)
@@ -1407,7 +1407,7 @@ impl Giganto {
     where
         T: Serialize + TryFromSysmonRecord + Unpin + Debug,
     {
-        info!("send sysmon, {protocol:?}");
+        info!("Send sysmon, {protocol:?}");
         let mut success_cnt = 0u64;
         let mut failed_cnt = 0u64;
         let mut pos = Position::new();
@@ -1457,7 +1457,7 @@ impl Giganto {
                             }
                             Err(e) => {
                                 failed_cnt += 1;
-                                error!("failed to convert data #{}: {e}", next_pos.line());
+                                warn!("Failed to convert data #{}: {e}", next_pos.line());
                             }
                         }
                     }
@@ -1466,7 +1466,7 @@ impl Giganto {
                     }
                     Err(e) => {
                         failed_cnt += 1;
-                        error!("invalid record: {e}");
+                        warn!("Invalid record: {e}");
                     }
                 }
                 pos = next_pos;
@@ -1490,14 +1490,14 @@ impl Giganto {
 
         self.init_msg = true;
         info!(
-            "last line: {}, success line: {}, failed line: {} ",
+            "Last line: {}, Success: {}, Failed: {}",
             pos.line(),
             success_cnt,
             failed_cnt
         );
 
         if let Err(e) = report.end() {
-            warn!("cannot write report: {e}");
+            warn!("Cannot write report: {e}");
         }
 
         Ok(pos.line())
@@ -1516,7 +1516,7 @@ impl Giganto {
     where
         T: Serialize + ParseNetflowDatasets + Unpin + Debug,
     {
-        info!("send netflow");
+        info!("Send netflow");
         let tmpl_path = env::var("NETFLOW_TEMPLATES_PATH");
         let mut templates = if let Ok(tmpl_path) = tmpl_path.as_ref() {
             TemplatesBox::from_path(tmpl_path).unwrap_or_default()
@@ -1616,7 +1616,7 @@ impl Giganto {
             ProcessStats::Packets,
             pkt_cnt.try_into().unwrap_or_default(),
         );
-        info!("netflow pcap processing statistics: {:?}", stats);
+        info!("Netflow pcap processing statistics: {:?}", stats);
         if !templates.is_empty() {
             if let Ok(tmpl_path) = tmpl_path.as_ref() {
                 if let Err(e) = templates.save(tmpl_path) {
@@ -1626,7 +1626,7 @@ impl Giganto {
         }
 
         if let Err(e) = report.end() {
-            warn!("cannot write report: {e}");
+            warn!("Cannot write report: {e}");
         }
 
         Ok(pkt_cnt)
@@ -1645,7 +1645,7 @@ impl Giganto {
     where
         T: Serialize + ParseSecurityLog + Unpin + Debug,
     {
-        info!("send seculog");
+        info!("Send seculog");
         let mut lines = reader.lines();
         let mut cnt = 0;
         let mut success_cnt = 0u64;
@@ -1713,12 +1713,12 @@ impl Giganto {
             self.send_event_in_batch(&buf).await?;
         }
         info!(
-            "last line: {}, success: {}, failed: {}",
+            "Last line: {}, Success: {}, Failed: {}",
             cnt, success_cnt, failed_cnt
         );
 
         if let Err(e) = report.end() {
-            warn!("cannot write report: {e}");
+            warn!("Cannot write report: {e}");
         }
 
         Ok(cnt)
@@ -1748,7 +1748,7 @@ impl Giganto {
                     line
                 }
                 Some(Err(e)) => {
-                    error!("failed to convert input data: {e}");
+                    error!("Failed to convert input data: {e}");
                     break;
                 }
                 None => {
@@ -1772,7 +1772,7 @@ impl Giganto {
             }
         }
         if let Err(e) = report.end() {
-            warn!("cannot write report: {e}");
+            warn!("Cannot write report: {e}");
         }
         Ok(conv_cnt + skip)
     }
@@ -1847,7 +1847,7 @@ impl Giganto {
                 break;
             }
         }
-        info!("Giganto end");
+        info!("Data Store ended");
         Ok(())
     }
 
@@ -1862,7 +1862,7 @@ impl Giganto {
             {
                 Ok(r) => r,
                 Err(quinn::ConnectionError::TimedOut) => {
-                    info!("server timeout, reconnecting...");
+                    info!("Server timeout, reconnecting...");
                     tokio::time::sleep(Duration::from_secs(INTERVAL)).await;
                     continue;
                 }
@@ -1944,13 +1944,13 @@ async fn recv_ack(mut recv: RecvStream, finish_checker: Arc<AtomicBool>) -> Resu
             Ok(timestamp) => {
                 if timestamp == CHANNEL_CLOSE_TIMESTAMP {
                     finish_checker.store(true, Ordering::SeqCst);
-                    info!("finish ACK: {timestamp}");
+                    info!("Finish ACK: {timestamp}");
                 } else {
                     info!("ACK: {timestamp}");
                 }
             }
             Err(RecvError::ReadError(quinn::ReadExactError::FinishedEarly(_))) => {
-                warn!("finished early");
+                warn!("Finished early");
                 break;
             }
             Err(e) => bail!("receive ACK err: {}", e),

--- a/src/syslog.rs
+++ b/src/syslog.rs
@@ -61,7 +61,7 @@ pub(crate) async fn fetch_elastic_search(elasticsearch: &ElasticSearch) -> Resul
 
     event_codes.par_iter().for_each(|&event_code| {
         let Ok(runtime) = tokio::runtime::Runtime::new() else {
-            error!("failed to init tokio runtime for event_code {event_code}");
+            error!("Failed to init tokio runtime for event_code {event_code}");
             return;
         };
         runtime.block_on(async {
@@ -208,7 +208,7 @@ fn process_event_data<T: EventToCsv + Serialize>(data: &Value, file_name: &str, 
 }
 
 fn write_to_csv<T: EventToCsv + Serialize>(entries: &Vec<T>, file_name: &str) -> io::Result<()> {
-    info!("{file_name}");
+    info!("CSV file name: {file_name}");
     if entries.is_empty() {
         return Ok(());
     }


### PR DESCRIPTION
Closes: #622

Notable:
- Removed internally-used name(giganto, reproduce) from log messages to improve readability.