### PR TITLE
Refactor FTP event structure to store commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Updated FTP event structure to support multiple commands per session instead
+  of single commands. The FTP struct now uses `Vec<FtpCommand>` to store all
+  commands and responses within a single FTP session, enabling comprehensive
+  session analysis and better alignment with actual FTP protocol behavior.
+- Modified FTP import functionality to parse tuple-formatted commands in
+  Giganto export files, supporting the new multi-command structure.
+- Updated Zeek FTP log processing to maintain backward compatibility while
+  adapting single commands to the new vector-based structure.
 - Renamed `last_time` field to `end_time` in raw event structures to improve
   clarity and consistency with the corresponding `start_time` field.
 - Renamed `duration` field to `end_time` in connection (`Conn`) raw event

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "giganto-client"
 version = "0.23.0"
-source = "git+https://github.com/aicers/giganto-client.git?rev=3e4939c#3e4939c7261dfcde1b6c5ea765a510eb8e4f4438"
+source = "git+https://github.com/aicers/giganto-client.git?rev=f52f942#f52f9427bc5b26a60c6cd49b534350d3551f2ada"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ chrono = "0.4"
 config = { version = "0.15", features = ["toml"], default-features = false }
 csv = "1"
 ctrlc = { version = "3", features = ["termination"] }
-giganto-client = { git = "https://github.com/aicers/giganto-client.git", rev = "3e4939c" }
+giganto-client = { git = "https://github.com/aicers/giganto-client.git", rev = "f52f942" }
 num-traits = "0.2"
 num_enum = "0.7"
 pcap = "2"

--- a/src/migration/tests.rs
+++ b/src/migration/tests.rs
@@ -92,7 +92,16 @@ fn giganto_dce_rpc() {
 
 #[test]
 fn giganto_ftp() {
-    let data = "1614130373.991064000	localhost	192.168.0.111	58459	192.168.0.7	49670	6	0.000000000	0.000000000	anonymous	ftp@example.com	EPSV	229	Entering Extended Passive Mode  (|||31746|)	true	192.168.4.76	196.216.2.24	31746	ftp://192.168.0.7/pub/stats/afrinic/delegated-afrinic-extended-latest.md5	74	226";
+    let data = r"1614130373.991064000	localhost	192.168.0.111	58459	192.168.0.7	49670	6	1614130373.991064000	1614130373.991064000	anonymous	ftp@example.com	(EPSV,229,Entering Extended Passive Mode,true,192.168.4.76,196.216.2.24,31746,ftp://192.168.0.7/pub/stats/afrinic/delegated-afrinic-extended-latest.md5,74,226)";
+
+    let rec = stringrecord(data);
+
+    assert!(Ftp::try_from_giganto_record(&rec).is_ok());
+}
+
+#[test]
+fn giganto_ftp_reply_230() {
+    let data = r"1614130373.991064000	localhost	192.168.0.111	21	192.168.0.7	49670	6	1614130373.991064000	1614130373.991064000	csanders	echo	(USER,230,User logged in, proceed,false,192.168.0.111,192.168.0.7,20,ftp://192.168.0.7/,0,1614130373991064000)";
 
     let rec = stringrecord(data);
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -57,7 +57,7 @@ use crate::{
 const CHANNEL_CLOSE_COUNT: u8 = 150;
 const CHANNEL_CLOSE_MESSAGE: &[u8; 12] = b"channel done";
 const CHANNEL_CLOSE_TIMESTAMP: i64 = -1;
-const REQUIRED_GIGANTO_VERSION: &str = "0.23.0";
+const REQUIRED_GIGANTO_VERSION: &str = "0.26.0-alpha.4";
 const INTERVAL: u64 = 5;
 const BATCH_SIZE: usize = 100;
 

--- a/src/zeek/network.rs
+++ b/src/zeek/network.rs
@@ -2,7 +2,7 @@ use std::net::IpAddr;
 
 use anyhow::{anyhow, Context, Result};
 use giganto_client::ingest::network::{
-    Conn, DceRpc, Dns, Ftp, Http, Kerberos, Ldap, Ntlm, Rdp, Smtp, Ssh, Tls,
+    Conn, DceRpc, Dns, Ftp, FtpCommand, Http, Kerberos, Ldap, Ntlm, Rdp, Smtp, Ssh, Tls,
 };
 use num_traits::ToPrimitive;
 
@@ -1081,6 +1081,20 @@ impl TryFromZeekRecord for Ftp {
         } else {
             return Err(anyhow!("missing data destination port"));
         };
+
+        let ftp_command = FtpCommand {
+            command,
+            reply_code,
+            reply_msg,
+            data_passive,
+            data_orig_addr,
+            data_resp_addr,
+            data_resp_port,
+            file: String::new(),
+            file_size: 0,
+            file_id: String::new(),
+        };
+
         Ok((
             Self {
                 orig_addr,
@@ -1092,16 +1106,7 @@ impl TryFromZeekRecord for Ftp {
                 end_time: i64::MAX,
                 user,
                 password,
-                command,
-                reply_code,
-                reply_msg,
-                data_passive,
-                data_orig_addr,
-                data_resp_addr,
-                data_resp_port,
-                file: String::new(),
-                file_size: 0,
-                file_id: String::new(),
+                commands: vec![ftp_command],
             },
             time,
         ))


### PR DESCRIPTION
## Related Issues

Closes #637

## PR Description

- Implement tuple-format FTP command parsing for the new `Vec<FtpCommand>` structure
- Add bidirectional parsing approach to correctly handle comma-containing reply messages
- Enhance error handling with safe indexing and descriptive error messages
- Include simple test coverage for FTP command scenarios

## Special Notes
- The tuple format follows: `(command,reply_code,reply_msg,data_passive,data_orig_addr,data_resp_addr
,data_resp_port,file,file_size,file_id)`
- Multiple commands are separated by commas: `(cmd1,reply1,...),(cmd2,reply2,...)`
- Special handling implemented for reply messages containing commas (e.g., reply code 230)
- This completes the FTP structure migration that was already documented in the CHANGELOG