### PR TITLE
Make pcap dependency optional via feature flag (#842)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/bin/reproduce/main.rs"
 
 [features]
 default = ["netflow"]
-netflow = ["pcap"]
+netflow = ["dep:pcap"]
 
 [dependencies]
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/lib.rs"
 name = "reproduce"
 path = "src/bin/reproduce/main.rs"
 
+[features]
+default = ["netflow"]
+netflow = ["pcap"]
+
 [dependencies]
 async-trait = "0.1"
 anyhow = "1"
@@ -25,7 +29,7 @@ giganto-client = { git = "https://github.com/aicers/giganto-client.git", rev = "
 jiff = { version = "0.2", features = ["serde"] }
 num-traits = "0.2"
 num_enum = "0.7"
-pcap = "2"
+pcap = { version = "2", optional = true }
 quinn = { version = "0.11", features = ["ring"] }
 rayon = "1"
 regex = "1"

--- a/src/bin/reproduce/kind_runners.rs
+++ b/src/bin/reproduce/kind_runners.rs
@@ -456,6 +456,7 @@ where
     }
 }
 
+#[cfg(feature = "netflow")]
 pub(super) async fn run_netflow_kind<S>(
     filename: &Path,
     kind: &str,

--- a/src/bin/reproduce/main.rs
+++ b/src/bin/reproduce/main.rs
@@ -15,10 +15,11 @@ mod tests;
 
 use anyhow::{Context as _, Result, anyhow, bail};
 use async_trait::async_trait;
+#[cfg(feature = "netflow")]
+use giganto_client::ingest::netflow::{Netflow5, Netflow9};
 use giganto_client::{
     RawEventKind,
     ingest::{
-        netflow::{Netflow5, Netflow9},
         network::{
             Bootp, Conn, DceRpc, Dhcp, Dns, Ftp, Http, Icmp, Kerberos, Ldap, MalformedDns, Mqtt,
             Nfs, Ntlm, Radius, Rdp, Smb, Smtp, Ssh, Tls,
@@ -35,6 +36,7 @@ use reproduce::collector::Collector;
 use reproduce::collector::file::files_in_dir;
 use reproduce::collector::log::LogCollector;
 use reproduce::collector::migration::MigrationCollector;
+#[cfg(feature = "netflow")]
 use reproduce::collector::netflow::NetflowCollector;
 use reproduce::collector::operation_log::OplogCollector;
 use reproduce::collector::security_log::SecurityLogCollector;
@@ -58,11 +60,12 @@ use tracing::{debug, error, info, warn};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{EnvFilter, Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
+#[cfg(feature = "netflow")]
+use crate::kind_runners::run_netflow_kind;
 use crate::{
     config::{Config, File as FileConfig, InputType},
     kind_runners::{
-        run_log_kind, run_netflow_kind, run_operation_log, run_security_kind, run_sysmon_kind,
-        run_zeek_kind,
+        run_log_kind, run_operation_log, run_security_kind, run_sysmon_kind, run_zeek_kind,
     },
     report::Report,
 };
@@ -388,12 +391,14 @@ impl SysmonKind {
     }
 }
 
+#[cfg(feature = "netflow")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum NetflowKind {
     Netflow5,
     Netflow9,
 }
 
+#[cfg(feature = "netflow")]
 impl NetflowKind {
     #[cfg(test)]
     const ALL: [Self; 2] = [Self::Netflow5, Self::Netflow9];
@@ -492,6 +497,7 @@ enum ClassifiedKind<'a> {
     Zeek(ZeekKind),
     OperationLog,
     Sysmon(SysmonKind),
+    #[cfg(feature = "netflow")]
     Netflow(NetflowKind),
     Security(SecurityKind),
     Log(&'a str),
@@ -517,12 +523,16 @@ fn classify_kind(kind: &str) -> ClassifiedKind<'_> {
         ClassifiedKind::OperationLog
     } else if let Some(kind) = SysmonKind::parse(kind) {
         ClassifiedKind::Sysmon(kind)
-    } else if let Some(kind) = NetflowKind::parse(kind) {
-        ClassifiedKind::Netflow(kind)
-    } else if let Some(kind) = SecurityKind::parse(kind) {
-        ClassifiedKind::Security(kind)
     } else {
-        ClassifiedKind::Log(kind)
+        #[cfg(feature = "netflow")]
+        if let Some(kind) = NetflowKind::parse(kind) {
+            return ClassifiedKind::Netflow(kind);
+        }
+        if let Some(kind) = SecurityKind::parse(kind) {
+            ClassifiedKind::Security(kind)
+        } else {
+            ClassifiedKind::Log(kind)
+        }
     }
 }
 
@@ -1014,6 +1024,7 @@ where
             .await?,
             true,
         ),
+        #[cfg(feature = "netflow")]
         ClassifiedKind::Netflow(kind) => (
             run_netflow_kind(filename, kind.as_str(), options, sender, report).await?,
             false,

--- a/src/bin/reproduce/tests.rs
+++ b/src/bin/reproduce/tests.rs
@@ -1,4 +1,5 @@
 use std::fs::{self, File};
+#[cfg(feature = "netflow")]
 use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
@@ -21,7 +22,9 @@ use tokio::time::timeout;
 use super::*;
 use crate::config::Directory;
 
+#[cfg(feature = "netflow")]
 const ETHERNET_DATALINK: u32 = 1;
+#[cfg(feature = "netflow")]
 const PROTO_UDP: u8 = 17;
 const TEST_ROOT_PEM: &str = "tests/root.pem";
 const TEST_CERT_PEM: &str = "tests/cert.pem";
@@ -172,6 +175,7 @@ fn write_text_file(dir: &tempfile::TempDir, name: &str, contents: &str) -> PathB
     path
 }
 
+#[cfg(feature = "netflow")]
 fn hex_to_bytes(s: &str) -> Vec<u8> {
     let filtered: String = s.chars().filter(|c| !c.is_whitespace()).collect();
     filtered
@@ -184,6 +188,7 @@ fn hex_to_bytes(s: &str) -> Vec<u8> {
         .collect()
 }
 
+#[cfg(feature = "netflow")]
 fn write_pcap(path: &Path, packets: &[Vec<u8>]) {
     let mut file = File::create(path).expect("pcap fixture should be created");
     file.write_all(&0xa1b2_c3d4_u32.to_le_bytes())
@@ -216,6 +221,7 @@ fn write_pcap(path: &Path, packets: &[Vec<u8>]) {
     }
 }
 
+#[cfg(feature = "netflow")]
 fn build_ipv4_udp_packet(payload: &[u8], dst_port: u16) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(&[0u8; 6]);
@@ -244,6 +250,7 @@ fn build_ipv4_udp_packet(payload: &[u8], dst_port: u16) -> Vec<u8> {
     bytes
 }
 
+#[cfg(feature = "netflow")]
 fn v5_header_bytes(count: u16) -> Vec<u8> {
     let mut bytes = Vec::new();
     bytes.extend_from_slice(&5u16.to_be_bytes());
@@ -258,6 +265,7 @@ fn v5_header_bytes(count: u16) -> Vec<u8> {
     bytes
 }
 
+#[cfg(feature = "netflow")]
 fn build_v5_packet(record_count: u16) -> Vec<u8> {
     let record = hex_to_bytes(include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
@@ -742,6 +750,7 @@ async fn run_single_processes_security_log_input() {
     assert_eq!(sender.ensured_protocols, vec![RawEventKind::SecuLog]);
 }
 
+#[cfg(feature = "netflow")]
 #[tokio::test]
 async fn run_single_processes_netflow_input() {
     let temp_dir = tempdir().expect("temporary directory should be created");
@@ -1012,6 +1021,7 @@ async fn run_security_kind_dispatches_all_supported_kinds() {
     }
 }
 
+#[cfg(feature = "netflow")]
 #[tokio::test]
 async fn run_netflow_kind_dispatches_all_supported_kinds_without_packets() {
     let temp_dir = tempdir().expect("temporary directory should be created");
@@ -1100,6 +1110,7 @@ async fn run_security_kind_rejects_unknown_kind() {
     assert!(err.to_string().contains("unknown security log kind"));
 }
 
+#[cfg(feature = "netflow")]
 #[tokio::test]
 async fn run_netflow_kind_rejects_unknown_kind() {
     let temp_dir = tempdir().expect("temporary directory should be created");

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,6 +1,7 @@
 pub mod file;
 pub mod log;
 pub mod migration;
+#[cfg(feature = "netflow")]
 pub mod netflow;
 pub mod operation_log;
 pub mod security_log;
@@ -17,6 +18,7 @@ use giganto_client::RawEventKind;
 use thiserror::Error;
 use tokio::sync::watch;
 
+#[cfg(feature = "netflow")]
 use crate::parser::netflow::NetflowError;
 
 /// Defines how long polling collectors sleep after reaching EOF.
@@ -57,6 +59,7 @@ impl From<anyhow::Error> for CollectorError {
     }
 }
 
+#[cfg(feature = "netflow")]
 impl From<NetflowError> for CollectorError {
     fn from(error: NetflowError) -> Self {
         Self(anyhow::Error::new(error))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,5 @@
 pub mod migration;
+#[cfg(feature = "netflow")]
 pub mod netflow;
 pub mod operation_log;
 pub mod security_log;


### PR DESCRIPTION
## Summary

- Gate the `pcap` crate behind an optional `netflow` Cargo feature so binaries that never use NetFlow (e.g. `reproduce-windows`) can build without `libpcap-dev` / Npcap SDK.
- Add `netflow` to `default` features so existing `reproduce` builds are unaffected.
- Gate `collector::netflow`, `parser::netflow`, and all related types, imports, and tests behind `#[cfg(feature = "netflow")]`.

Closes #842

## Test plan

- [x] `cargo check --no-default-features` succeeds without `libpcap-dev`
- [x] `cargo check` (default features) succeeds
- [x] `cargo test --all-targets` passes all existing tests
- [x] `reproduce-windows` binary compiles with `--no-default-features` — N/A: binary not yet added; verified via `cargo check --no-default-features` on the library crate