### PR TITLE
Rename agent terminology to service

### DIFF
--- a/src/bin/reproduce/kind_runners.rs
+++ b/src/bin/reproduce/kind_runners.rs
@@ -263,13 +263,13 @@ where
         dir_polling_mode,
         shutdown,
     } = options;
-    let agent = operation_log_agent_name(filename)?;
+    let service_name = operation_log_service_name(filename)?;
     let oplog = File::open(filename)?;
     let rdr = BufReader::new(oplog);
     run_collector(
         OplogCollector::new(
             rdr,
-            agent.to_string(),
+            service_name.to_string(),
             offset,
             count_sent,
             file_polling_mode,

--- a/src/bin/reproduce/main.rs
+++ b/src/bin/reproduce/main.rs
@@ -166,7 +166,7 @@ fn init_tracing(log_path: Option<&std::path::Path>) -> anyhow::Result<WorkerGuar
     Ok(guard)
 }
 
-const AGENTS_LIST: [&str; 7] = [
+const SERVICE_NAMES: [&str; 7] = [
     "manager",
     "data_store",
     "sensor",
@@ -1144,20 +1144,20 @@ fn checkpoint_offset(checkpoint: &Checkpoint) -> u64 {
     }
 }
 
-fn operation_log_agent_name(path: &Path) -> Result<&str> {
+fn operation_log_service_name(path: &Path) -> Result<&str> {
     let file_name = path
         .file_name()
         .with_context(|| format!("missing file name in {}", path.display()))?;
     let file_name = file_name
         .to_str()
         .with_context(|| format!("invalid unicode in {}", path.display()))?;
-    let (agent, _) = file_name
+    let (service_name, _) = file_name
         .split_once('.')
         .with_context(|| format!("operation log file must have an extension: {file_name}"))?;
-    if AGENTS_LIST.contains(&agent) {
-        Ok(agent)
+    if SERVICE_NAMES.contains(&service_name) {
+        Ok(service_name)
     } else {
-        bail!("invalid agent name `{file_name}`");
+        bail!("invalid service name `{file_name}`");
     }
 }
 

--- a/src/bin/reproduce/tests.rs
+++ b/src/bin/reproduce/tests.rs
@@ -461,7 +461,7 @@ fn input_type_nonexistent_path() {
 }
 
 #[test]
-fn valid_agent_filenames() {
+fn valid_service_filenames() {
     let valid_filenames = [
         "manager.log",
         "data_store.txt",
@@ -474,13 +474,16 @@ fn valid_agent_filenames() {
 
     for filename in valid_filenames {
         let path = Path::new(filename);
-        let result = operation_log_agent_name(path);
-        assert!(result.is_ok(), "Expected valid agent filename: {filename}");
+        let result = operation_log_service_name(path);
+        assert!(
+            result.is_ok(),
+            "Expected valid service filename: {filename}"
+        );
     }
 }
 
 #[test]
-fn valid_agent_filenames_with_directory() {
+fn valid_service_filenames_with_directory() {
     let valid_paths = [
         "/var/log/manager.txt",
         "/home/user/logs/data_store.csv",
@@ -491,30 +494,30 @@ fn valid_agent_filenames_with_directory() {
 
     for path_str in valid_paths {
         let path = Path::new(path_str);
-        let result = operation_log_agent_name(path);
+        let result = operation_log_service_name(path);
         assert!(
             result.is_ok(),
-            "Expected valid agent filename with path: {path_str}"
+            "Expected valid service filename with path: {path_str}"
         );
     }
 }
 
 #[test]
-fn invalid_agent_name_returns_error() {
-    let invalid_agent_filenames = [
-        "unknown_agent.txt",
+fn invalid_service_name_returns_error() {
+    let invalid_service_filenames = [
+        "unknown_service.txt",
         "invalid.csv",
         "test.json",
         "other_service.dat",
-        "agent.out",
+        "service.out",
     ];
 
-    for filename in invalid_agent_filenames {
+    for filename in invalid_service_filenames {
         let path = Path::new(filename);
-        let result = operation_log_agent_name(path);
+        let result = operation_log_service_name(path);
         assert!(
             result.is_err(),
-            "Expected invalid agent name to return an error: {filename}"
+            "Expected invalid service name to return an error: {filename}"
         );
     }
 }
@@ -522,7 +525,7 @@ fn invalid_agent_name_returns_error() {
 #[test]
 fn returns_error_on_filename_without_dot() {
     let path = Path::new("manager_no_extension");
-    let err = operation_log_agent_name(path).expect_err("missing extension must be rejected");
+    let err = operation_log_service_name(path).expect_err("missing extension must be rejected");
     assert!(err.to_string().contains("must have an extension"));
 }
 
@@ -530,12 +533,12 @@ fn returns_error_on_filename_without_dot() {
 fn returns_error_on_empty_path() {
     let path = Path::new("/");
     let err =
-        operation_log_agent_name(path).expect_err("path without a file name must be rejected");
+        operation_log_service_name(path).expect_err("path without a file name must be rejected");
     assert!(err.to_string().contains("missing file name"));
 }
 
 #[test]
-fn valid_agent_with_different_extensions() {
+fn valid_service_with_different_extensions() {
     let valid_with_other_ext = [
         "manager.txt",
         "sensor.csv",
@@ -545,10 +548,10 @@ fn valid_agent_with_different_extensions() {
 
     for filename in valid_with_other_ext {
         let path = Path::new(filename);
-        let result = operation_log_agent_name(path);
+        let result = operation_log_service_name(path);
         assert!(
             result.is_ok(),
-            "Expected valid agent name regardless of extension: {filename}"
+            "Expected valid service name regardless of extension: {filename}"
         );
     }
 }

--- a/src/collector/operation_log.rs
+++ b/src/collector/operation_log.rs
@@ -18,7 +18,7 @@ use crate::sender::BATCH_SIZE;
 /// batching them for sending.
 pub struct OplogCollector {
     lines: Lines<BufReader<File>>,
-    agent: String,
+    service_name: String,
     skip: u64,
     count_sent: u64,
     file_polling_mode: bool,
@@ -35,11 +35,11 @@ pub struct OplogCollector {
 impl OplogCollector {
     /// Creates a new `OplogCollector`.
     ///
-    /// `agent` is the agent name embedded in each `OpLog` record.
+    /// `service_name` is the service name embedded in each `OpLog` record.
     #[must_use]
     pub fn new(
         reader: BufReader<File>,
-        agent: String,
+        service_name: String,
         skip: u64,
         count_sent: u64,
         file_polling_mode: bool,
@@ -48,7 +48,7 @@ impl OplogCollector {
     ) -> Self {
         Self {
             lines: reader.lines(),
-            agent,
+            service_name,
             skip,
             count_sent,
             file_polling_mode,
@@ -92,7 +92,7 @@ impl Collector for OplogCollector {
                 }
 
                 let (oplog_data, timestamp) =
-                    if let Ok(r) = operation_log::log_regex(&line, &self.agent) {
+                    if let Ok(r) = operation_log::log_regex(&line, &self.service_name) {
                         self.success_cnt += 1;
                         r
                     } else {

--- a/src/parser/giganto_import/tests.rs
+++ b/src/parser/giganto_import/tests.rs
@@ -79,7 +79,7 @@ fn giganto_ntlm() {
 
 #[test]
 fn giganto_kerberos() {
-    let data = "1562093132.125665000	localhost	89.248.167.131	24067	210.117.142.55	88	0	0.000000000	0	1	0	21515	27889	0.000000000	0.000000000	1	client_realm	1	client,name	realm	1	service,name";
+    let data = "1562093132.125665000	localhost	89.248.167.131	24067	210.117.142.55	88	0	0.000000000	0	1	0	21515	27889	0.000000000	0.000000000	1	client_realm	1	cname1,cname2	realm	1	sname1,sname2";
 
     let rec = stringrecord(data);
 

--- a/src/parser/operation_log.rs
+++ b/src/parser/operation_log.rs
@@ -170,14 +170,14 @@ mod tests {
         ];
 
         for (line, expected_level) in valid_lines {
-            let result = log_regex(line, "test_agent");
+            let result = log_regex(line, "test_service");
             assert!(result.is_ok(), "Expected valid log line: {line}");
             let (oplog, _) = result.unwrap();
             assert!(
                 matches!(oplog.log_level, ref level if std::mem::discriminant(level) == std::mem::discriminant(&expected_level)),
                 "Unexpected log level for: {line}"
             );
-            assert_eq!(oplog.service_name, "test_agent");
+            assert_eq!(oplog.service_name, "test_service");
         }
     }
 
@@ -203,20 +203,20 @@ mod tests {
         ];
 
         for line in invalid_lines {
-            let result = log_regex(line, "agent");
+            let result = log_regex(line, "test_service");
             assert!(result.is_err(), "Expected error for invalid line: {line}");
         }
     }
 
     #[test]
-    fn log_regex_preserves_agent_name() {
-        // Agent name should be passed through unchanged
+    fn log_regex_preserves_service_name() {
+        // Service name should be passed through unchanged
         let line = "2023-01-02T07:36:17Z  INFO test message";
-        let agents = ["manager", "data_store", "sensor", "custom_agent"];
+        let service_names = ["manager", "data_store", "sensor", "custom_service"];
 
-        for agent in agents {
-            let (oplog, _) = log_regex(line, agent).unwrap();
-            assert_eq!(oplog.service_name, agent);
+        for service_name in service_names {
+            let (oplog, _) = log_regex(line, service_name).unwrap();
+            assert_eq!(oplog.service_name, service_name);
         }
     }
 
@@ -236,7 +236,7 @@ mod tests {
         ];
 
         for (line, expected_content) in test_cases {
-            let (oplog, _) = log_regex(line, "agent").unwrap();
+            let (oplog, _) = log_regex(line, "test_service").unwrap();
             assert_eq!(oplog.contents, expected_content);
         }
     }
@@ -280,7 +280,7 @@ mod tests {
         ];
 
         for (line, expected_nanos) in test_cases {
-            let (_, timestamp) = log_regex(line, "agent").unwrap();
+            let (_, timestamp) = log_regex(line, "test_service").unwrap();
             assert_eq!(
                 timestamp, expected_nanos,
                 "Timestamp mismatch for line: {line}"


### PR DESCRIPTION
Close: #849

- Renamed remaining `agent` identifiers to `service` in the oplog-related logic and tests.
- Replaced test data and variable names with more neutral terms where `service` was unnecessary in context. (`kerberos` test code)
- Left the `service` fields in `smb` and `conn`, as well as the `agent_*` fields in `sysmon` events, unchanged because those names come from their respective data schemas.
